### PR TITLE
Build XLA extension as tarball

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.github/scripts/compile_unless_exists.sh
+++ b/.github/scripts/compile_unless_exists.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ex
+
+cd "$(dirname "$0")/../.."
+
+# Ensure tasks are compiled
+mix compile
+
+tag=$(mix xla.info release_tag)
+
+if gh release list | grep $tag; then
+  archive_filename=$(mix xla.info archive_filename)
+
+  if gh release view $tag | grep $archive_filename; then
+    echo "Found $archive_filename in $tag release artifacts, skipping compilation"
+  else
+    XLA_BUILD=true mix compile
+  fi
+else
+  echo "::error::Release $tag not found"
+  exit 1
+fi

--- a/.github/scripts/publish_release.sh
+++ b/.github/scripts/publish_release.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")/../.."
+
+# Ensure tasks are compiled
+mix compile
+
+tag=$(mix xla.info release_tag)
+
+if gh release list | grep -q $tag; then
+  echo "Release $tag already exists, make sure to bump the version in mix.exs"
+  exit 1
+fi
+
+if [[ $(git diff @ @{upstream} | wc -c) -ne 0 ]]; then
+  echo "Your git working directory is not up to date with remote, make sure to push the changes first"
+  exit 1
+fi
+
+read -p "This will publish a new release $tag and trigger the release build. Do you want to continue? [y/N] "
+if [[ ! $REPLY =~ ^[yY]$ ]]; then
+  exit 0
+fi
+
+gh release create $tag --notes ""
+
+echo "Successfully created release $tag. Remember to wait for the release build to finish before publishing the Hex package."

--- a/.github/scripts/upload_archives.sh
+++ b/.github/scripts/upload_archives.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ex
+
+cd "$(dirname "$0")/../.."
+
+# Ensure tasks are compiled
+mix compile
+
+tag=$(mix xla.info release_tag)
+
+cd cache/build
+
+for file in *.tar.gz; do
+  # Uploading is the final action after several hour long build,
+  # so in case of any temporary network failures we want to retry
+  # a number of times
+  for i in {1..10}; do
+    gh release upload --clobber $tag $file && break
+    echo "Upload failed, retrying in 30s"
+    sleep 30
+  done
+done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,182 @@
+name: Release
+on:
+  release:
+    types: [published]
+jobs:
+  # linux x86_64 cpu/tpu
+  linux:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "24"
+          elixir-version: "1.12.3"
+      # Setup the compilation environment
+      - uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: "3.7.2"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - run: python -m pip install --upgrade pip numpy
+      # Build and upload the archives
+      - run: mix deps.get
+      - run: .github/scripts/compile_unless_exists.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          XLA_TARGET: cpu
+          CC: gcc-9
+      - run: .github/scripts/compile_unless_exists.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          XLA_TARGET: tpu
+          CC: gcc-9
+      - run: .github/scripts/upload_archives.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # darwin x86_64 cpu
+  macos:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - run: brew install elixir
+      - run: mix local.hex --force
+      # Setup the compilation environment
+      - uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: "3.7.2"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - run: python -m pip install --upgrade pip numpy
+      # Build and upload the archive
+      - run: mix deps.get
+      - run: .github/scripts/compile_unless_exists.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          XLA_TARGET: cpu
+          CC: gcc-9
+      - run: .github/scripts/upload_archives.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # linux x86_64 cuda
+  linux_cuda:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - container: nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04
+            xla_target: cuda111
+            python: "3.9"
+            image_os: ubuntu20
+          - container: nvidia/cuda:11.0.3-cudnn8-devel-ubuntu20.04
+            xla_target: cuda110
+            python: "3.9"
+            image_os: ubuntu20
+          - container: nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
+            xla_target: cuda102
+            python: "3.6.9"
+            image_os: ubuntu18
+    container: ${{ matrix.container }}
+    env:
+      # This env is normally set by default, but we need to mirror it into the container
+      # ourselves (used by the actions/setup-beam).
+      ImageOS: ${{ matrix.image_os }}
+      # Set the missing utf-8 locales, otherwise Elixir warns
+      LANG: en_US.UTF-8
+      LANGUAGE: en_US:en
+      LC_ALL: en_US.UTF-8
+      # Make sure installing packages (like tzdata) doesn't prompt for configuration
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      # The base images are minimalistic, so we bring a few necessary system packages
+      - name: Install system packages
+        run: |
+          # We need to install "add-apt-repository" first
+          apt-get update && apt-get install -y software-properties-common
+          # Add repository with the latest git version for action/checkout to properly clone the repo
+          add-apt-repository ppa:git-core/ppa
+          # We run as root, so sudo is not necessary per se, but some actions (like setup-bazel) make use of it
+          apt-get update && apt-get install -y locales ca-certificates curl git sudo unzip wget
+          # Install GitHub CLI used by our scripts
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          apt-get update && apt-get install -y gh
+          # Update locales
+          echo "$LANG UTF-8" >> /etc/locale.gen
+          locale-gen
+          update-locale LANG=$LANG
+      # Proceed with the regular steps
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "24"
+          elixir-version: "1.12.3"
+      # Setup the compilation environment
+      - uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: "3.7.2"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+        env:
+          # Avoid permission errors for /github/home, in this case the directory
+          # is used for pip cache and is not relevant either way
+          HOME: /root
+      - run: python -m pip install --upgrade pip numpy
+      # Build and upload the archive
+      - run: mix deps.get
+      - run: .github/scripts/compile_unless_exists.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          XLA_TARGET: ${{ matrix.xla_target }}
+      - run: .github/scripts/upload_archives.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # windows x86_64 cpu
+  windows:
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "24"
+          elixir-version: "1.12.3"
+      # Setup the compilation environment
+      - uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: "3.7.2"
+      # We rely on the default Python installation, since using setup-python results
+      # in errors when building with Bazel
+      - run: python -m pip install --upgrade pip numpy
+      # Update Visual Studio installer to avoid errors in the subsequent installation.
+      # See https://github.com/jberezanski/ChocolateyPackages/issues/97#issuecomment-798688284
+      - run: choco upgrade -y visualstudio2019enterprise
+      # Install Visual Studio Build Tools
+      - run: choco install -y visualstudio2019buildtools visualstudio2019-workload-vctools
+      # Set up the environment, specifically this makes nmake discoverable in PATH
+      - uses: ilammy/msvc-dev-cmd@v1
+      # Build and upload the archives
+      - run: mix deps.get
+      # Compute the parent dir and set it as an environment variable
+      - run: echo "PARENT_DIR=$(Resolve-Path "..")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - run: .github/scripts/compile_unless_exists.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          XLA_TARGET: cpu
+          # The default HOME is on the C: drive and for some reason working
+          # there leads to issues, so we use a local location instead
+          HOME: ${{ env.PARENT_DIR }}
+          # This should be inferred automatically, but bazel fails unless we set this explicitly
+          # See https://docs.bazel.build/versions/main/windows.html#build-c-with-msvc
+          BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC"
+        shell: bash
+      - run: .github/scripts/upload_archives.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+xla-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/
+
+# Ignore all the archives
+/cache/

--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,18 @@ ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 BAZEL_FLAGS = --define "framework_shared_object=false" -c $(BUILD_MODE)
 
 TENSORFLOW_NS = tf-$(TENSORFLOW_GIT_REV)
-TENSORFLOW_DIR = $(BUILD_CACHE)/$(TENSORFLOW_NS)/
+TENSORFLOW_DIR = $(BUILD_CACHE)/$(TENSORFLOW_NS)
 TENSORFLOW_XLA_EXTENSION_NS = tensorflow/compiler/xla/extension
 TENSORFLOW_XLA_EXTENSION_DIR = $(TENSORFLOW_DIR)/$(TENSORFLOW_XLA_EXTENSION_NS)
 
 $(TENSORFLOW_DIR)/bazel-bin/$(TENSORFLOW_EXLA_NS)/xla_extension: symlinks
 	cd $(TENSORFLOW_DIR) && \
-		bazel build $(BAZEL_FLAGS) $(XLA_EXTENSION_FLAGS) //$(TENSORFLOW_XLA_EXTENSION_NS):xla_extension
+		bazel build $(BAZEL_FLAGS) $(XLA_EXTENSION_FLAGS) //$(TENSORFLOW_XLA_EXTENSION_NS):xla_extension && \
+                cp -f $(TENSORFLOW_DIR)/bazel-bin/$(TENSORFLOW_XLA_EXTENSION_NS)/xla_extension.tar.gz $(ROOT_DIR)/xla_extension.tar.gz
 
 
 symlinks: $(TENSORFLOW_DIR)
-	@ rm -f $(TENSORFLOW_EXLA_DIR)
+	@ rm -f $(TENSORFLOW_XLA_EXTENSION_DIR)
 	@ ln -s "$(ROOT_DIR)/extension" $(TENSORFLOW_XLA_EXTENSION_DIR)
 
 # Print Tensorflow Dir
@@ -46,3 +47,4 @@ clean:
 	cd $(TENSORFLOW_DIR) && bazel clean --expunge
 	rm -f $(TENSORFLOW_XLA_EXTENSION_DIR)
 	rm -rf $(TENSORFLOW_DIR)
+	rm -rf $(ROOT_DIR)/xla_extension.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEMP ?= $(HOME)/.cache
 
 # Public configuration
 BUILD_MODE ?= opt # can also be dbg
-BUILD_CACHE ?= $(TEMP)/exla
+BUILD_CACHE ?= $(TEMP)/xla_extension
 TENSORFLOW_GIT_REPO ?= https://github.com/tensorflow/tensorflow.git
 
 # TODO: Should this instead be a stable version source?
@@ -12,7 +12,7 @@ TENSORFLOW_GIT_REV ?= 54dee6dd8d47b6e597f4d3f85b6fb43fd5f50f82
 
 # Private configuration
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-BAZEL_FLAGS = --define "framework_shared_object=false" -c $(EXLA_MODE)
+BAZEL_FLAGS = --define "framework_shared_object=false" -c $(BUILD_MODE)
 
 TENSORFLOW_NS = tf-$(TENSORFLOW_GIT_REV)
 TENSORFLOW_DIR = $(BUILD_CACHE)/$(TENSORFLOW_NS)/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+# System vars
+TEMP ?= $(HOME)/.cache
+
+# Public configuration
+BUILD_MODE ?= opt # can also be dbg
+BUILD_CACHE ?= $(TEMP)/exla
+TENSORFLOW_GIT_REPO ?= https://github.com/tensorflow/tensorflow.git
+
+# TODO: Should this instead be a stable version source?
+# e.g. instead use wget to download tagged releases
+TENSORFLOW_GIT_REV ?= 54dee6dd8d47b6e597f4d3f85b6fb43fd5f50f82
+
+# Private configuration
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+BAZEL_FLAGS = --define "framework_shared_object=false" -c $(EXLA_MODE)
+
+TENSORFLOW_NS = tf-$(TENSORFLOW_GIT_REV)
+TENSORFLOW_DIR = $(BUILD_CACHE)/$(TENSORFLOW_NS)/
+TENSORFLOW_XLA_EXTENSION_NS = tensorflow/compiler/xla/extension
+TENSORFLOW_XLA_EXTENSION_DIR = $(TENSORFLOW_DIR)/$(TENSORFLOW_XLA_EXTENSION_NS)
+
+$(TENSORFLOW_DIR)/bazel-bin/$(TENSORFLOW_EXLA_NS)/xla_extension: symlinks
+	cd $(TENSORFLOW_DIR) && \
+		bazel build $(BAZEL_FLAGS) $(XLA_EXTENSION_FLAGS) //$(TENSORFLOW_XLA_EXTENSION_NS):xla_extension
+
+
+symlinks: $(TENSORFLOW_DIR)
+	@ rm -f $(TENSORFLOW_EXLA_DIR)
+	@ ln -s "$(ROOT_DIR)/extension" $(TENSORFLOW_XLA_EXTENSION_DIR)
+
+# Print Tensorflow Dir
+PTD:
+	@ echo $(TENSORFLOW_DIR)
+
+# Clones tensorflow
+$(TENSORFLOW_DIR):
+	mkdir -p $(TENSORFLOW_DIR)
+
+	cd $(TENSORFLOW_DIR) && \
+		git init && \
+		git remote add origin $(TENSORFLOW_GIT_REPO) && \
+		git fetch --depth 1 origin $(TENSORFLOW_GIT_REV) && \
+		git checkout FETCH_HEAD
+
+clean:
+	cd $(TENSORFLOW_DIR) && bazel clean --expunge
+	rm -f $(TENSORFLOW_XLA_EXTENSION_DIR)
+	rm -rf $(TENSORFLOW_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+# Environment variables passed via elixir_make
+# ROOT_DIR
+# BUILD_ARCHIVE
+# BUILD_INTERNAL_FLAGS
+
 # System vars
 TEMP ?= $(HOME)/.cache
 
@@ -11,40 +16,37 @@ TENSORFLOW_GIT_REPO ?= https://github.com/tensorflow/tensorflow.git
 TENSORFLOW_GIT_REV ?= 54dee6dd8d47b6e597f4d3f85b6fb43fd5f50f82
 
 # Private configuration
-ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 BAZEL_FLAGS = --define "framework_shared_object=false" -c $(BUILD_MODE)
 
 TENSORFLOW_NS = tf-$(TENSORFLOW_GIT_REV)
 TENSORFLOW_DIR = $(BUILD_CACHE)/$(TENSORFLOW_NS)
 TENSORFLOW_XLA_EXTENSION_NS = tensorflow/compiler/xla/extension
 TENSORFLOW_XLA_EXTENSION_DIR = $(TENSORFLOW_DIR)/$(TENSORFLOW_XLA_EXTENSION_NS)
+TENSORFLOW_XLA_BUILD_ARCHIVE = $(TENSORFLOW_DIR)/bazel-bin/$(TENSORFLOW_XLA_EXTENSION_NS)/xla_extension.tar.gz
 
-$(TENSORFLOW_DIR)/bazel-bin/$(TENSORFLOW_EXLA_NS)/xla_extension: symlinks
-	cd $(TENSORFLOW_DIR) && \
-		bazel build $(BAZEL_FLAGS) $(XLA_EXTENSION_FLAGS) //$(TENSORFLOW_XLA_EXTENSION_NS):xla_extension && \
-                cp -f $(TENSORFLOW_DIR)/bazel-bin/$(TENSORFLOW_XLA_EXTENSION_NS)/xla_extension.tar.gz $(ROOT_DIR)/xla_extension.tar.gz
-
-
-symlinks: $(TENSORFLOW_DIR)
-	@ rm -f $(TENSORFLOW_XLA_EXTENSION_DIR)
-	@ ln -s "$(ROOT_DIR)/extension" $(TENSORFLOW_XLA_EXTENSION_DIR)
-
-# Print Tensorflow Dir
-PTD:
-	@ echo $(TENSORFLOW_DIR)
+$(BUILD_ARCHIVE): $(TENSORFLOW_DIR) extension/BUILD
+	rm -f $(TENSORFLOW_XLA_EXTENSION_DIR) && \
+		ln -s "$(ROOT_DIR)/extension" $(TENSORFLOW_XLA_EXTENSION_DIR) && \
+		cd $(TENSORFLOW_DIR) && \
+		bazel build $(BAZEL_FLAGS) $(BUILD_FLAGS) $(BUILD_INTERNAL_FLAGS) //$(TENSORFLOW_XLA_EXTENSION_NS):xla_extension && \
+		mkdir -p $(dir $(BUILD_ARCHIVE)) && \
+		cp -f $(TENSORFLOW_XLA_BUILD_ARCHIVE) $(BUILD_ARCHIVE)
 
 # Clones tensorflow
 $(TENSORFLOW_DIR):
-	mkdir -p $(TENSORFLOW_DIR)
-
-	cd $(TENSORFLOW_DIR) && \
+	mkdir -p $(TENSORFLOW_DIR) && \
+		cd $(TENSORFLOW_DIR) && \
 		git init && \
 		git remote add origin $(TENSORFLOW_GIT_REPO) && \
 		git fetch --depth 1 origin $(TENSORFLOW_GIT_REV) && \
 		git checkout FETCH_HEAD
 
+# Print Tensorflow Dir
+PTD:
+	@ echo $(TENSORFLOW_DIR)
+
 clean:
 	cd $(TENSORFLOW_DIR) && bazel clean --expunge
 	rm -f $(TENSORFLOW_XLA_EXTENSION_DIR)
 	rm -rf $(TENSORFLOW_DIR)
-	rm -rf $(ROOT_DIR)/xla_extension.tar.gz
+	rm -rf $(TARGET_DIR)

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,63 @@
+# Environment variables passed via elixir_make
+# ROOT_DIR
+# BUILD_ARCHIVE
+# BUILD_ARCHIVE_DIR
+# BUILD_INTERNAL_FLAGS
+
+# System vars
+TEMP=$(HOME)/.cache
+
+# Public configuration
+!IFNDEF BUILD_MODE
+BUILD_MODE=opt # can also be dbg
+!ENDIF
+
+!IFNDEF BUILD_CACHE
+BUILD_CACHE=$(TEMP)/xla_extension
+!ENDIF
+
+!IFNDEF TENSORFLOW_GIT_REPO
+TENSORFLOW_GIT_REPO=https://github.com/tensorflow/tensorflow.git
+!ENDIF
+
+# TODO: Should this instead be a stable version source?
+# e.g. instead use wget to download tagged releases
+!IFNDEF TENSORFLOW_GIT_REV
+TENSORFLOW_GIT_REV=54dee6dd8d47b6e597f4d3f85b6fb43fd5f50f82
+!ENDIF
+
+# Private configuration
+BAZEL_FLAGS=--define "framework_shared_object=false" -c $(BUILD_MODE)
+
+TENSORFLOW_NS=tf-$(TENSORFLOW_GIT_REV)
+TENSORFLOW_DIR=$(BUILD_CACHE)/$(TENSORFLOW_NS)
+TENSORFLOW_XLA_EXTENSION_NS=tensorflow/compiler/xla/extension
+TENSORFLOW_XLA_EXTENSION_DIR=$(TENSORFLOW_DIR)/$(TENSORFLOW_XLA_EXTENSION_NS)
+TENSORFLOW_XLA_BUILD_ARCHIVE=$(TENSORFLOW_DIR)/bazel-bin/$(TENSORFLOW_XLA_EXTENSION_NS)/xla_extension.tar.gz
+
+$(BUILD_ARCHIVE): $(TENSORFLOW_DIR) extension/BUILD
+	rm -rf "$(TENSORFLOW_XLA_EXTENSION_DIR)" && \
+		ln -s "$(ROOT_DIR)/extension" "$(TENSORFLOW_XLA_EXTENSION_DIR)" && \
+		cd "$(TENSORFLOW_DIR)" && \
+		bazel build $(BAZEL_FLAGS) $(BUILD_FLAGS) $(BUILD_INTERNAL_FLAGS) //$(TENSORFLOW_XLA_EXTENSION_NS):xla_extension && \
+		mkdir -f "$(BUILD_ARCHIVE_DIR)" && \
+		cp -f "$(TENSORFLOW_XLA_BUILD_ARCHIVE)" "$(BUILD_ARCHIVE)"
+
+# Clones tensorflow
+$(TENSORFLOW_DIR):
+	mkdir "$(TENSORFLOW_DIR)" && \
+		cd "$(TENSORFLOW_DIR)" && \
+		git init && \
+		git remote add origin $(TENSORFLOW_GIT_REPO) && \
+		git fetch --depth 1 origin $(TENSORFLOW_GIT_REV) && \
+		git checkout FETCH_HEAD
+
+# Print Tensorflow Dir
+PTD:
+	@ echo "$(TENSORFLOW_DIR)"
+
+clean:
+	cd "$(TENSORFLOW_DIR)" && bazel clean --expunge
+	rm -rf "$(TENSORFLOW_XLA_EXTENSION_DIR)"
+	rm -rf "$(TENSORFLOW_DIR)"
+	rm -rf "$(TARGET_DIR)"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,142 @@
-# xla
-Pre-compiled XLA extension
+# XLA
+
+Precompiled Google's XLA binaries for [EXLA](https://github.com/elixir-nx/nx/tree/main/exla).
+
+## Usage
+
+EXLA already depends on this package, so you generally don't need to install it yourself.
+There is however a number of environment variables that you may want to use in order to
+customize the variant of XLA binary.
+
+The binaries are always built/downloaded to match the current configuration, so you should
+set the environment variables in `.bash_profile` or a similar configuration file so you don't
+need to export it in every shell session.
+
+#### `XLA_TARGET`
+
+The default value is `cpu`, which implies the final the binary supports targeting
+only the host CPU.
+
+| Value | Target environment |
+| --- | --- |
+| cpu | |
+| tpu | libtpu |
+| cuda111 | CUDA 11.1+, cuDNN |
+| cuda110 | CUDA 11.0, cuDNN |
+| cuda102 | CUDA 10.2, cuDNN |
+| cuda | CUDA x.y, cuDNN |
+| rocm | ROCm |
+
+To use XLA with NVidia GPU you need [CUDA](https://developer.nvidia.com/cuda-downloads)
+and [cuDNN](https://developer.nvidia.com/cudnn) compatible with your GPU drivers.
+See [the installation instructions](https://docs.nvidia.com/deeplearning/cudnn/install-guide/index.html)
+and [the cuDNN support matrix](https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html)
+for version compatibility. To use precompiled XLA binaries specify a target matching
+your CUDA version (like `cuda111`). When building from source it's enough to specify
+`cuda` as the target.
+
+#### `XLA_BUILD`
+
+Defaults to `false`. If `true` the binary is built locally, which may be intended
+if no precompiled binary is available for your target environment. Building has
+a number of dependencies, see *Building from source* below.
+
+#### `XLA_ARCHIVE_URL`
+
+A URL pointing to a specific build of the `.tar.gz` archive. When using this option
+you need to make sure the build matches your OS, CPU architecture and the XLA target.
+
+## Building from source
+
+To build the XLA binaries locally you need to set `XLA_BUILD=true` and possibly `XLA_TARGET`.
+Keep in mind that the compilation usually takes a very long time.
+
+You will need the following installed in your system for the compilation:
+
+  * [Git](https://git-scm.com/) for fetching Tensorflow source
+  * [Bazel v3.7.2](https://bazel.build/) for compiling Tensorflow
+  * [Python3](https://python.org) with NumPy installed for compiling Tensorflow
+
+If running on Windows, you will also need:
+
+  * [MSYS2](https://www.msys2.org/)
+  * [Microsoft Build Tools 2019](https://visualstudio.microsoft.com/downloads/)
+  * [Microsoft Visual C++ 2019 Redistributable](https://visualstudio.microsoft.com/downloads/)
+
+### Common issues
+
+#### Bazel version
+
+Use `bazel --version` to check your Bazel version, make sure you are using v3.7.2.
+Most binaries are available on [Github](https://github.com/bazelbuild/bazel/releases),
+but it can also be installed with `asdf`:
+
+```shell
+asdf plugin-add bazel
+asdf install bazel 3.7.2
+asdf global bazel 3.7.2
+```
+
+#### GCC
+
+You may have issues with newer and older versions of GCC. TensorFlow builds are known to work
+with GCC versions between 7.5 and 9.3. If your system uses a newer GCC version, you can install
+an older version and tell Bazel to use it with `export CC=/path/to/gcc-{version}` where version
+is the GCC version you installed
+
+#### Python and asdf
+
+`Bazel` cannot find `python` installed via the `asdf` version manager by default. `asdf` uses a
+function to lookup the specified version of a given binary, this approach prevents `Bazel` from
+being able to correctly build XLA. The error is `unknown command: python. Perhaps you have to reshim?`.
+There are two known workarounds:
+
+1. Use a separate installer or explicitly change your `$PATH` to point to a Python installation (note
+   the build process looks for `python`, not `python3`). For example, on Homebrew on macOS, you would do:
+
+    ```shell
+    export PATH=/usr/local/opt/python@3.9/libexec/bin:/usr/local/bin:$PATH
+    ```
+
+2. Use the [`asdf direnv`](https://github.com/asdf-community/asdf-direnv) plugin to install [`direnv 2.20.0`](https://direnv.net).
+   `direnv` along with the `asdf-direnv` plugin will explicitly set the paths for any binary specified
+   in your project's `.tool-versions` files.
+
+If you still get the error, you can also try setting `PYTHON_BIN_PATH`, like `export PYTHON_BIN_PATH=/usr/bin/python3.9`.
+
+After doing any of the steps above, it may be necessary to clear the build cache by removing ` ~/.cache/xla_extension`.
+
+### GPU support
+
+To build binaries with GPU support, you need all the GPU-specific dependencies (CUDA, ROCm),
+then you can build with either `XLA_TARGET=cuda` or `XLA_TARGET=rocm`. See the `XLA_TARGET`
+for more details.
+
+### TPU support
+
+All you need is setting `XLA_TARGET=tpu`.
+
+### Compilation-specific environment variables
+
+You can use the following env vars to customize your build:
+
+  * `BUILD_CACHE` - controls where to store Tensorflow source and builds
+
+  * `BUILD_FLAGS` - additional flags passed to Bazel
+
+  * `BUILD_MODE` - controls to compile `opt` (default) artifacts or `dbg`, example: `BUILD_MODE=dbg`
+
+## Runtime flags
+
+You can further configure XLA runtime options with `XLA_FLAGS`,
+see: [tensorflow/compiler/xla/debug_options_flags.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/debug_options_flags.cc)
+for the list of available flags.
+
+## Release process
+
+To publish a new version of this package:
+
+1. Update version in `mix.exs`.
+2. Run `.github/scripts/publish_release.sh`.
+3. Wait for the release workflow to build all the binaries.
+4. Publish the package to Hex.

--- a/extension/BUILD
+++ b/extension/BUILD
@@ -132,7 +132,4 @@ pkg_tar(
     ":xla_extension_lib",
     ":xla_extension_headers",
   ],
-  remap_paths = {
-    "./xla_extension/include/include/": "./xla_extension/include/",
-  }
 )

--- a/extension/BUILD
+++ b/extension/BUILD
@@ -97,11 +97,31 @@ genrule(
         d="$${d#*external/farmhash_archive/src}"
         d="$${d#*external/$${extname}/}"
       fi
+      # Remap llvm paths
+      d="$${d/llvm\/include\/llvm/llvm}"
+      d="$${d/llvm\/include\/llvm-c/llvm-c}"
+      # Remap google path
+      d="$${d/src\/google/google}"
+      # Remap grpc paths
+      d="$${d/include\/grpc/grpc}"
       mkdir -p "$@/$${d}"
       cp "$${f}" "$@/$${d}/"
     done
     """,
   )
+
+# This genrule remaps libxla_extension.so to lib/libxla_extension.so
+genrule(
+  name = "xla_extension_lib",
+  srcs = [
+    ":libxla_extension.so",
+  ],
+  outs = ["lib"],
+  cmd = """
+    mkdir $@
+    mv $(location :libxla_extension.so) $@
+  """
+)
 
 pkg_tar(
   name = "xla_extension",
@@ -109,10 +129,10 @@ pkg_tar(
   mode = "0644",
   package_dir = "xla_extension",
   srcs = [
-    ":libxla_extension.so",
+    ":xla_extension_lib",
     ":xla_extension_headers",
   ],
   remap_paths = {
-    "libxla_extension.so" : "lib/libxla_extension.so"
+    "./xla_extension/include/include/": "./xla_extension/include/",
   }
 )

--- a/extension/BUILD
+++ b/extension/BUILD
@@ -1,0 +1,118 @@
+load("@org_tensorflow//tensorflow:tensorflow.bzl", "if_cuda_or_rocm",)
+load("@org_tensorflow//tensorflow:tensorflow.bzl", "if_with_tpu_support",)
+load("@org_tensorflow//tensorflow:tensorflow.bzl", "tf_grpc_cc_dependency",)
+load("@org_tensorflow//tensorflow:tensorflow.bzl", "transitive_hdrs",)
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar",)
+
+package(default_visibility=["//visibility:private"])
+
+# Static library which contains dependencies necessary for building on
+# top of XLA
+cc_binary(
+  name = "libxla_extension.so",
+  deps = [
+    "@com_google_absl//absl/types:span",
+    "@com_google_absl//absl/types:optional",
+    "@com_google_absl//absl/base:log_severity",
+    "@org_tensorflow//tensorflow/core/common_runtime:bfc_allocator",
+    "@org_tensorflow//tensorflow/compiler/xla:util",
+    "@org_tensorflow//tensorflow/compiler/xla:statusor",
+    "@org_tensorflow//tensorflow/compiler/xla:comparison_util",
+    "@org_tensorflow//tensorflow/compiler/xla:xla_data_proto_cc",
+    "@org_tensorflow//tensorflow/compiler/xla:literal",
+    "@org_tensorflow//tensorflow/compiler/xla:shape_util",
+    "@org_tensorflow//tensorflow/compiler/xla:status",
+    "@org_tensorflow//tensorflow/compiler/xla:types",
+    "@org_tensorflow//tensorflow/compiler/xla/service:platform_util",
+    "@org_tensorflow//tensorflow/compiler/xla/client:client",
+    "@org_tensorflow//tensorflow/compiler/xla/client:client_library",
+    "@org_tensorflow//tensorflow/compiler/xla/client:xla_builder",
+    "@org_tensorflow//tensorflow/compiler/xla/client:xla_computation",
+    "@org_tensorflow//tensorflow/compiler/xla/client:executable_build_options",
+    "@org_tensorflow//tensorflow/compiler/xla/client/lib:lu_decomposition",
+    "@org_tensorflow//tensorflow/compiler/xla/client/lib:math",
+    "@org_tensorflow//tensorflow/compiler/xla/client/lib:qr",
+    "@org_tensorflow//tensorflow/compiler/xla/client/lib:svd",
+    "@org_tensorflow//tensorflow/compiler/xla/client/lib:self_adjoint_eig",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt/distributed:protocol",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt/distributed:protocol_proto_cc",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt:pjrt_client",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt:gpu_device",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt/distributed:client",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt:pjrt_stream_executor_client",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt:local_device_state",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt:event_pool",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt:semaphore",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt:worker_thread",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt:tracked_device_buffer",
+    "@org_tensorflow//tensorflow/compiler/jit:xla_cpu_jit",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt:cpu_device",
+    "@org_tensorflow//tensorflow/compiler/xla/pjrt:tpu_client",
+    "@org_tensorflow//tensorflow/core:lib",
+    "@org_tensorflow//tensorflow/core:lib_internal_impl",
+    # GRPC Dependency (needed for PjRt distributed)
+    tf_grpc_cc_dependency(),
+  ] + if_with_tpu_support([
+    "@org_tensorflow//tensorflow/core/tpu:tpu_executor_dlsym_initializer",
+  ]) + if_cuda_or_rocm([
+    "@org_tensorflow//tensorflow/compiler/xla/service:gpu_plugin",
+  ]),
+  linkopts = ["-shared"],
+  linkshared = 1,
+)
+
+# Transitive hdrs gets all headers required by deps, including
+# transitive dependencies, it seems though it generates a lot
+# of unused headers as well
+transitive_hdrs(
+  name = "xla_extension_dep_headers",
+  deps = [
+    ":libxla_extension.so",
+  ]
+)
+
+# This is the genrule used by TF install headers to correctly
+# map headers into a directory structure
+genrule(
+  name = "xla_extension_headers",
+  srcs = [
+    ":xla_extension_dep_headers",
+  ],
+  outs = ["include"],
+  cmd = """
+    mkdir $@
+    for f in $(SRCS); do
+      d="$${f%/*}"
+      d="$${d#bazel-out/*/genfiles/}"
+      d="$${d#bazel-out/*/bin/}"
+      if [[ $${d} == *local_config_* ]]; then
+        continue
+      fi
+      if [[ $${d} == external* ]]; then
+        extname="$${d#*external/}"
+        extname="$${extname%%/*}"
+        if [[ $${TF_SYSTEM_LIBS:-} == *$${extname}* ]]; then
+          continue
+        fi
+        d="$${d#*external/farmhash_archive/src}"
+        d="$${d#*external/$${extname}/}"
+      fi
+      mkdir -p "$@/$${d}"
+      cp "$${f}" "$@/$${d}/"
+    done
+    """,
+  )
+
+pkg_tar(
+  name = "xla_extension",
+  extension = "tar.gz",
+  mode = "0644",
+  package_dir = "xla_extension",
+  srcs = [
+    ":libxla_extension.so",
+    ":xla_extension_headers",
+  ],
+  remap_paths = {
+    "libxla_extension.so" : "lib/libxla_extension.so"
+  }
+)

--- a/lib/mix/tasks/xla.info.ex
+++ b/lib/mix/tasks/xla.info.ex
@@ -1,0 +1,24 @@
+defmodule Mix.Tasks.Xla.Info do
+  @moduledoc """
+  Returns relevant information about the XLA archive.
+  """
+
+  use Mix.Task
+
+  @impl true
+  def run(["archive_filename"]) do
+    Mix.shell().info(XLA.archive_filename_with_target())
+  end
+
+  def run(["release_tag"]) do
+    Mix.shell().info(XLA.release_tag())
+  end
+
+  def run(_args) do
+    Mix.shell().error("""
+    Usage:
+    mix xla.info archive_filename
+    mix xla.info release_tag\
+    """)
+  end
+end

--- a/lib/xla.ex
+++ b/lib/xla.ex
@@ -1,0 +1,226 @@
+defmodule XLA do
+  @moduledoc """
+  API for accessing compiled XLA archives.
+  """
+
+  require Logger
+
+  @github_repo "elixir-nx/xla"
+
+  # The directory where we store all the archives
+  @cache_dir Path.expand("../cache", __DIR__)
+  @build_dir Path.join(@cache_dir, "build")
+  @download_dir Path.join(@cache_dir, "download")
+  @external_dir Path.join(@cache_dir, "external")
+
+  @doc """
+  Returns path to the precompiled XLA archive.
+
+  Depending on the environment variables configuration,
+  the path will point to either built or downloaded file.
+  If not found locally, the file is downloaded when calling
+  this function.
+  """
+  @spec archive_path!() :: Path.t()
+  def archive_path!() do
+    cond do
+      build?() ->
+        # The archive should have already been built by this point
+        archive_path_for_build()
+
+      url = xla_archive_url() ->
+        path = archive_path_for_external_download(url)
+        unless File.exists?(path), do: download_external!(url, path)
+        path
+
+      true ->
+        path = archive_path_for_matching_download()
+        unless File.exists?(path), do: download_matching!(path)
+        path
+    end
+  end
+
+  defp build?() do
+    System.get_env("XLA_BUILD") in ~w(1 true)
+  end
+
+  defp xla_archive_url() do
+    System.get_env("XLA_ARCHIVE_URL")
+  end
+
+  defp xla_target() do
+    target = System.get_env("XLA_TARGET", "cpu")
+
+    supported_xla_targets = ["cpu", "cuda", "rocm", "tpu", "cuda102", "cuda110", "cuda111"]
+
+    unless target in supported_xla_targets do
+      listing = supported_xla_targets |> Enum.map(&inspect/1) |> Enum.join(", ")
+      raise "expected XLA_TARGET to be one of #{listing}, but got: #{inspect(target)}"
+    end
+
+    target
+  end
+
+  @doc false
+  def make_env() do
+    bazel_build_flags =
+      case xla_target() do
+        "cuda" <> _ -> "--config=cuda"
+        "rocm" <> _ -> "--config=rocm --action_env=HIP_PLATFORM=hcc"
+        "tpu" <> _ -> "--config=tpu"
+        _ -> ""
+      end
+
+    # Additional environment variables passed to make
+    %{
+      "BUILD_INTERNAL_FLAGS" => bazel_build_flags,
+      "ROOT_DIR" => Path.expand("..", __DIR__),
+      "BUILD_ARCHIVE" => archive_path_for_build(),
+      "BUILD_ARCHIVE_DIR" => Path.dirname(archive_path_for_build())
+    }
+  end
+
+  @doc false
+  def release_tag() do
+    version = Application.spec(:xla, :vsn)
+    "v" <> to_string(version)
+  end
+
+  @doc false
+  def archive_filename_with_target() do
+    "xla_extension-#{target()}.tar.gz"
+  end
+
+  defp target() do
+    {cpu, os} =
+      :erlang.system_info(:system_architecture)
+      |> List.to_string()
+      |> String.split("-")
+      |> case do
+        ["arm" <> _, _vendor, "darwin" <> _ | _] -> {"aarch64", "darwin"}
+        [cpu, _vendor, "darwin" <> _ | _] -> {cpu, "darwin"}
+        [cpu, _vendor, os | _] -> {cpu, os}
+        ["win32"] -> {"x86_64", "windows"}
+      end
+
+    "#{cpu}-#{os}-#{xla_target()}"
+  end
+
+  defp archive_path_for_build() do
+    filename = archive_filename_with_target()
+    Path.join(@build_dir, filename)
+  end
+
+  defp archive_path_for_external_download(url) do
+    hash = url |> :erlang.md5() |> Base.encode32(case: :lower, padding: false)
+    filename = "xla_extension-#{hash}.tar.gz"
+    Path.join(@external_dir, filename)
+  end
+
+  defp archive_path_for_matching_download() do
+    filename = archive_filename_with_target()
+    Path.join(@download_dir, filename)
+  end
+
+  defp download_external!(url, archive_path) do
+    assert_network_tool!()
+    Logger.info("Downloading XLA archive from #{url}")
+    download_archive!(url, archive_path)
+  end
+
+  defp download_matching!(archive_path) do
+    assert_network_tool!()
+
+    expected_filename = Path.basename(archive_path)
+
+    filenames =
+      case list_release_files() do
+        {:ok, filenames} ->
+          filenames
+
+        :error ->
+          raise "could not find #{release_tag()} release under https://github.com/#{@github_repo}/releases"
+      end
+
+    unless expected_filename in filenames do
+      listing = filenames |> Enum.map(&["    * ", &1, "\n"]) |> IO.iodata_to_binary()
+
+      raise "none of the precompiled archives matches your target\n" <>
+              "  Expected:\n" <>
+              "    * #{expected_filename}\n" <>
+              "  Found:\n" <>
+              listing <>
+              "\nYou can compile XLA locally by setting an environment variable: XLA_BUILD=true"
+    end
+
+    Logger.info("Found a matching archive (#{expected_filename}), going to download it")
+    url = release_file_url(expected_filename)
+    download_archive!(url, archive_path)
+  end
+
+  defp download_archive!(url, archive_path) do
+    File.mkdir_p!(Path.dirname(archive_path))
+
+    if download(url, archive_path) == :error do
+      raise "failed to download the XLA archive from #{url}"
+    end
+
+    Logger.info("Successfully downloaded the XLA archive")
+  end
+
+  defp assert_network_tool!() do
+    unless network_tool() do
+      raise "expected either curl or wget to be available in your system, but neither was found"
+    end
+  end
+
+  defp list_release_files() do
+    url = "https://api.github.com/repos/#{@github_repo}/releases/tags/#{release_tag()}"
+
+    with {:ok, body} <- get(url) do
+      # We don't have a JSON library available here, so we do
+      # a simple matching
+      {:ok, Regex.scan(~r/"name":\s+"(.*\.tar\.gz)"/, body) |> Enum.map(&Enum.at(&1, 1))}
+    end
+  end
+
+  defp release_file_url(filename) do
+    "https://github.com/#{@github_repo}/releases/download/#{release_tag()}/#{filename}"
+  end
+
+  defp download(url, dest) do
+    command =
+      case network_tool() do
+        :curl -> "curl --fail -L #{url} -o #{dest}"
+        :wget -> "wget -O #{dest} #{url}"
+      end
+
+    case System.shell(command) do
+      {_, 0} -> :ok
+      _ -> :error
+    end
+  end
+
+  defp get(url) do
+    command =
+      case network_tool() do
+        :curl -> "curl --fail --silent -L #{url}"
+        :wget -> "wget -q -O - #{url}"
+      end
+
+    case System.shell(command) do
+      {body, 0} -> {:ok, body}
+      _ -> :error
+    end
+  end
+
+  defp network_tool() do
+    cond do
+      executable_exists?("curl") -> :curl
+      executable_exists?("wget") -> :wget
+      true -> nil
+    end
+  end
+
+  defp executable_exists?(name), do: System.find_executable(name) != nil
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,40 @@
+defmodule XLA.MixProject do
+  use Mix.Project
+
+  @version "0.1.0"
+
+  def project do
+    [
+      app: :xla,
+      version: @version,
+      description: "Precompiled Google's XLA binaries",
+      elixir: "~> 1.12",
+      deps: deps(),
+      compilers: Mix.compilers() ++ if(build?(), do: [:elixir_make], else: []),
+      make_env: &XLA.make_env/0,
+      package: package()
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [{:elixir_make, "~> 0.4", runtime: false}]
+  end
+
+  def package do
+    [
+      licenses: ["Apache-2.0"],
+      links: %{
+        "GitHub" => "https://github.com/elixir-nx/xla"
+      },
+      files: ~w(extension Makefile mix.exs README.md LICENSE CHANGELOG.md)
+    ]
+  end
+
+  defp build?() do
+    System.get_env("XLA_BUILD") == "true"
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,3 @@
+%{
+  "elixir_make": {:hex, :elixir_make, "0.6.2", "7dffacd77dec4c37b39af867cedaabb0b59f6a871f89722c25b28fcd4bd70530", [:mix], [], "hexpm", "03e49eadda22526a7e5279d53321d1cced6552f344ba4e03e619063de75348d9"},
+}


### PR DESCRIPTION
Builds a tarball with XLA dependencies including all required headers and a single shared-object which can be linked in to other executables to make use of TensorFlow XLA without Bazel, Python, NumPy, and the rest of the TensorFlow build stuff.

As is this works, but I had to a do some troubleshooting manually that should be automated:

1. `xla_data.pb.h` cannot find `port_def.inc`. `port_def.inc` is apparently a file from Google protobuf. I fixed this by finding the location of my TensorFlow installation and then adding `-I$(TF_INCLUDE_DIR)`. We need to find a way to ensure that's packaged into the tarball without depending on a global TF install

2. `grpcpp/grpcpp.h` not found in `pjrt/distributed/channel.h`. GRPCPP is included in an `include` dir which somehow gets mapped inside the top-level `include` dir, this can be fixed by moving GRPCPP from `include/include/grpcpp` to `include/grpcpp`. We can automate this with some bazel magic I think.

3. `llvm/target/TargetMachine.h` not found in `xla/service/cpu`. An `llvm` folder exists in the top-level include, but XLA is actually looking for the contents of `llvm/include/llvm` - so moving `llvm/include/llvm` to top-level include directory fixes this. Again this is a problem with how Bazel is mapping some of these paths/includes

4. `xla/client/lib/lu_decomposition.h` not found. For some reason this header gets lost? I guess we can copy it in somehow - that's what I did.

5. The current rules package A LOT of transitive headers and dependencies. Honestly not sure which ones are necessary. I manually deleted like 80% of the folders generated inside `include` and everything worked just fine, but I'm not sure if that's going to base the case in every circumstance. 