### PR TITLE
Build on ubuntu18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,9 @@ on:
 jobs:
   # linux x86_64 cpu/tpu
   linux:
-    runs-on: ubuntu-20.04
+    # We intentionally build on ubuntu 18 to compile against
+    # an older version of glibc
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
@@ -64,28 +66,25 @@ jobs:
 
   # linux x86_64 cuda
   linux_cuda:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
         include:
-          - container: nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04
+          - container: nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04
             xla_target: cuda111
             python: "3.9"
-            image_os: ubuntu20
-          - container: nvidia/cuda:11.0.3-cudnn8-devel-ubuntu20.04
+          - container: nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
             xla_target: cuda110
             python: "3.9"
-            image_os: ubuntu20
           - container: nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
             xla_target: cuda102
             python: "3.6.9"
-            image_os: ubuntu18
     container: ${{ matrix.container }}
     env:
       # This env is normally set by default, but we need to mirror it into the container
       # ourselves (used by the actions/setup-beam).
-      ImageOS: ${{ matrix.image_os }}
+      ImageOS: ubuntu18
       # Set the missing utf-8 locales, otherwise Elixir warns
       LANG: en_US.UTF-8
       LANGUAGE: en_US:en

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v0.1.1](https://github.com/elixir-nx/xla/tree/v0.1.1) (2021-09-16)
+
+### Changed
+
+* Build for older glibc versions ([#3](https://github.com/elixir-nx/xla/pull/3))
+
 ## [v0.1.0](https://github.com/elixir-nx/xla/tree/v0.1.0) (2021-09-16)
 
 Initial release.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule XLA.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
 
   def project do
     [


### PR DESCRIPTION
This improves compatibility by building against an older version of glibc.

Once https://github.com/elixir-nx/nx/pull/455 is merged, we can merge this, publish a new release, and once it builds we can bump the xla dependency in exla.