### PR TITLE
Disable windows build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,45 +137,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # windows x86_64 cpu
-  windows:
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: "24"
-          elixir-version: "1.12.3"
-      # Setup the compilation environment
-      - uses: abhinavsingh/setup-bazel@v3
-        with:
-          version: "3.7.2"
-      # We rely on the default Python installation, since using setup-python results
-      # in errors when building with Bazel
-      - run: python -m pip install --upgrade pip numpy
-      # Update Visual Studio installer to avoid errors in the subsequent installation.
-      # See https://github.com/jberezanski/ChocolateyPackages/issues/97#issuecomment-798688284
-      - run: choco upgrade -y visualstudio2019enterprise
-      # Install Visual Studio Build Tools
-      - run: choco install -y visualstudio2019buildtools visualstudio2019-workload-vctools
-      # Set up the environment, specifically this makes nmake discoverable in PATH
-      - uses: ilammy/msvc-dev-cmd@v1
-      # Build and upload the archives
-      - run: mix deps.get
-      # Compute the parent dir and set it as an environment variable
-      - run: echo "PARENT_DIR=$(Resolve-Path "..")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      - run: .github/scripts/compile_unless_exists.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          XLA_TARGET: cpu
-          # The default HOME is on the C: drive and for some reason working
-          # there leads to issues, so we use a local location instead
-          HOME: ${{ env.PARENT_DIR }}
-          # This should be inferred automatically, but bazel fails unless we set this explicitly
-          # See https://docs.bazel.build/versions/main/windows.html#build-c-with-msvc
-          BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC"
-        shell: bash
-      - run: .github/scripts/upload_archives.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
+  # Note: the Windows build is disabled until Windows is supported on EXLA side
+
+  # # windows x86_64 cpu
+  # windows:
+  #   runs-on: windows-2019
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: erlef/setup-beam@v1
+  #       with:
+  #         otp-version: "24"
+  #         elixir-version: "1.12.3"
+  #     # Setup the compilation environment
+  #     - uses: abhinavsingh/setup-bazel@v3
+  #       with:
+  #         version: "3.7.2"
+  #     # We rely on the default Python installation, since using setup-python results
+  #     # in errors when building with Bazel
+  #     - run: python -m pip install --upgrade pip numpy
+  #     # Update Visual Studio installer to avoid errors in the subsequent installation.
+  #     # See https://github.com/jberezanski/ChocolateyPackages/issues/97#issuecomment-798688284
+  #     - run: choco upgrade -y visualstudio2019enterprise
+  #     # Install Visual Studio Build Tools
+  #     - run: choco install -y visualstudio2019buildtools visualstudio2019-workload-vctools
+  #     # Set up the environment, specifically this makes nmake discoverable in PATH
+  #     - uses: ilammy/msvc-dev-cmd@v1
+  #     # Build and upload the archives
+  #     - run: mix deps.get
+  #     # Compute the parent dir and set it as an environment variable
+  #     - run: echo "PARENT_DIR=$(Resolve-Path "..")" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+  #     - run: .github/scripts/compile_unless_exists.sh
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         XLA_TARGET: cpu
+  #         # The default HOME is on the C: drive and for some reason working
+  #         # there leads to issues, so we use a local location instead
+  #         HOME: ${{ env.PARENT_DIR }}
+  #         # This should be inferred automatically, but bazel fails unless we set this explicitly
+  #         # See https://docs.bazel.build/versions/main/windows.html#build-c-with-msvc
+  #         BAZEL_VC: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC"
+  #       shell: bash
+  #     - run: .github/scripts/upload_archives.sh
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       shell: bash


### PR DESCRIPTION
I think it doesn't make sense to keep building windows binaries until we figure out how to integrate it into EXLA build process, especially in case the resulting archive is invalid. Also, the windows job is by far the longest (last time it took `5h 57m` and `6h` is the limit).