### PR TITLE
Bump required Bazel version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       # Setup the compilation environment
       - uses: abhinavsingh/setup-bazel@v3
         with:
-          version: "3.7.2"
+          version: "4.2.1"
       - uses: actions/setup-python@v2
         with:
           python-version: "3.9"
@@ -48,7 +48,7 @@ jobs:
       # Setup the compilation environment
       - uses: abhinavsingh/setup-bazel@v3
         with:
-          version: "3.7.2"
+          version: "4.2.1"
       - uses: actions/setup-python@v2
         with:
           python-version: "3.9"
@@ -74,7 +74,6 @@ jobs:
       # Setup the compilation environment
       - uses: abhinavsingh/setup-bazel@v3
         with:
-          # For this specific build we want a more recent Bazel
           version: "4.2.1"
       - uses: actions/setup-python@v2
         with:
@@ -156,7 +155,7 @@ jobs:
       # Setup the compilation environment
       - uses: abhinavsingh/setup-bazel@v3
         with:
-          version: "3.7.2"
+          version: "4.2.1"
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
@@ -189,7 +188,7 @@ jobs:
   #     # Setup the compilation environment
   #     - uses: abhinavsingh/setup-bazel@v3
   #       with:
-  #         version: "3.7.2"
+  #         version: "4.2.1"
   #     # We rely on the default Python installation, since using setup-python results
   #     # in errors when building with Bazel
   #     - run: python -m pip install --upgrade pip numpy

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Keep in mind that the compilation usually takes a very long time.
 You will need the following installed in your system for the compilation:
 
   * [Git](https://git-scm.com/) for fetching Tensorflow source
-  * [Bazel v3.7.2](https://bazel.build/) for compiling Tensorflow
+  * [Bazel v4.2.1](https://bazel.build/) for compiling Tensorflow
   * [Python3](https://python.org) with NumPy installed for compiling Tensorflow
 
 If running on Windows, you will also need:
@@ -73,14 +73,14 @@ If running on Windows, you will also need:
 
 #### Bazel version
 
-Use `bazel --version` to check your Bazel version, make sure you are using v3.7.2.
+Use `bazel --version` to check your Bazel version, make sure you are using v4.2.1.
 Most binaries are available on [Github](https://github.com/bazelbuild/bazel/releases),
 but it can also be installed with `asdf`:
 
 ```shell
 asdf plugin-add bazel
-asdf install bazel 3.7.2
-asdf global bazel 3.7.2
+asdf install bazel 4.2.1
+asdf global bazel 4.2.1
 ```
 
 #### GCC
@@ -121,11 +121,6 @@ for more details.
 ### TPU support
 
 All you need is setting `XLA_TARGET=tpu`.
-
-### Apple Silicon
-
-Building on Apple Silicon requires a newer version of Bazel, it's been verified
-to work with `4.2.1`.
 
 ### Compilation-specific environment variables
 


### PR DESCRIPTION
See https://github.com/elixir-nx/xla/pull/10#discussion_r716532660.

I think we can keep `.bazelversion` removed, if someone runs into problems the README explicitly points at Bazel version as one of possible problems.