### PR TITLE
Bump TensorFlow to 2.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ BUILD_MODE ?= opt # can also be dbg
 BUILD_CACHE ?= $(TEMP)/xla_extension
 TENSORFLOW_GIT_REPO ?= https://github.com/tensorflow/tensorflow.git
 
-# Tensorflow 2.6.0
-TENSORFLOW_GIT_REV ?= 919f693420e35d00c8d0a42100837ae3718f7927
+# Tensorflow 2.8.0
+TENSORFLOW_GIT_REV ?= 3f878cff5b698b82eea85db2b60d65a2e320850e
 
 # Private configuration
 BAZEL_FLAGS = --define "framework_shared_object=false" -c $(BUILD_MODE)

--- a/Makefile.win
+++ b/Makefile.win
@@ -21,8 +21,8 @@ TENSORFLOW_GIT_REPO=https://github.com/tensorflow/tensorflow.git
 !ENDIF
 
 !IFNDEF TENSORFLOW_GIT_REV
-# Tensorflow 2.6.0
-TENSORFLOW_GIT_REV=919f693420e35d00c8d0a42100837ae3718f7927
+# Tensorflow 2.8.0
+TENSORFLOW_GIT_REV=3f878cff5b698b82eea85db2b60d65a2e320850e
 !ENDIF
 
 # Private configuration

--- a/extension/BUILD
+++ b/extension/BUILD
@@ -1,6 +1,6 @@
 load("@org_tensorflow//tensorflow:tensorflow.bzl", "if_cuda_or_rocm",)
 load("@org_tensorflow//tensorflow:tensorflow.bzl", "if_with_tpu_support",)
-load("@org_tensorflow//tensorflow:tensorflow.bzl", "tf_grpc_cc_dependency",)
+load("@org_tensorflow//tensorflow:tensorflow.bzl", "tf_grpc_cc_dependencies",)
 load("@org_tensorflow//tensorflow:tensorflow.bzl", "transitive_hdrs",)
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar",)
 
@@ -50,11 +50,13 @@ cc_binary(
     "@org_tensorflow//tensorflow/compiler/xla/pjrt:tpu_client",
     "@org_tensorflow//tensorflow/core:lib",
     "@org_tensorflow//tensorflow/core:lib_internal_impl",
-    # GRPC Dependency (needed for PjRt distributed)
-    tf_grpc_cc_dependency(),
-  ] + if_with_tpu_support([
+  ]
+  # GRPC Dependencies (needed for PjRt distributed)
+  + tf_grpc_cc_dependencies()
+  + if_with_tpu_support([
     "@org_tensorflow//tensorflow/core/tpu:tpu_executor_dlsym_initializer",
-  ]) + if_cuda_or_rocm([
+  ])
+  + if_cuda_or_rocm([
     "@org_tensorflow//tensorflow/compiler/xla/service:gpu_plugin",
   ]),
   linkopts = ["-shared"],
@@ -100,6 +102,8 @@ genrule(
       # Remap llvm paths
       d="$${d/llvm\\/include\\/llvm/llvm}"
       d="$${d/llvm\\/include\\/llvm-c/llvm-c}"
+      # Remap mlir paths
+      d="$${d/mlir\\/include\\/mlir/mlir}"
       # Remap google path
       d="$${d/src\\/google/google}"
       # Remap grpc paths


### PR DESCRIPTION
Just some tiny changes to the BUILD script, and there is one API change relevant for EXLA (https://github.com/elixir-nx/nx/compare/main...jonatanklosko:jk-tf280). With that, all EXLA tests pass for ma locally (cannot tell about GPU though).