### PR TITLE
Require CUDA 11.1+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 jobs:
   # linux x86_64 cpu/tpu
   linux:
@@ -103,25 +104,19 @@ jobs:
 
   # linux x86_64 cuda
   linux_cuda:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         include:
-          - container: nvidia/cuda:11.1.1-cudnn8-devel-ubuntu18.04
+          - container: nvidia/cuda:11.1.1-cudnn8-devel-ubuntu20.04
             xla_target: cuda111
             python: "3.9"
-          - container: nvidia/cuda:11.0.3-cudnn8-devel-ubuntu18.04
-            xla_target: cuda110
-            python: "3.9"
-          - container: nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04
-            xla_target: cuda102
-            python: "3.6.9"
     container: ${{ matrix.container }}
     env:
       # This env is normally set by default, but we need to mirror it into the container
       # ourselves (used by the actions/setup-beam).
-      ImageOS: ubuntu18
+      ImageOS: ubuntu20
       # Set the missing utf-8 locales, otherwise Elixir warns
       LANG: en_US.UTF-8
       LANGUAGE: en_US:en

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * Bumped XLA (Tensorflow) version to 2.8.0 ([#15](https://github.com/elixir-nx/xla/pull/15))
 
+### Removed
+
+* Dropped support for CUDA 10.2 and 11.0, now 11.1+ is required ([#17](https://github.com/elixir-nx/xla/pull/17))
+
 ## [v0.2.0](https://github.com/elixir-nx/xla/tree/v0.2.0) (2021-09-23)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ only the host CPU.
 | cpu | |
 | tpu | libtpu |
 | cuda111 | CUDA 11.1+, cuDNN |
-| cuda110 | CUDA 11.0, cuDNN |
-| cuda102 | CUDA 10.2, cuDNN |
 | cuda | CUDA x.y, cuDNN |
 | rocm | ROCm |
 

--- a/lib/xla.ex
+++ b/lib/xla.ex
@@ -46,7 +46,7 @@ defmodule XLA do
   defp xla_target() do
     target = System.get_env("XLA_TARGET", "cpu")
 
-    supported_xla_targets = ["cpu", "cuda", "rocm", "tpu", "cuda102", "cuda110", "cuda111"]
+    supported_xla_targets = ["cpu", "cuda", "rocm", "tpu", "cuda111"]
 
     unless target in supported_xla_targets do
       listing = supported_xla_targets |> Enum.map(&inspect/1) |> Enum.join(", ")


### PR DESCRIPTION
Building for CUDA 10.2 and 11.0 on the CI failed because of a missing CUDA header file. Apparently jaxlib [dropped support for these](https://github.com/google/jax/blob/main/CHANGELOG.md#jaxlib-0172-oct-12-2021), so we are doing the same.