### PR TITLE
Add sorting library

### DIFF
--- a/extension/BUILD
+++ b/extension/BUILD
@@ -24,6 +24,7 @@ cc_binary(
     "@org_tensorflow//tensorflow/compiler/xla/client/lib:qr",
     "@org_tensorflow//tensorflow/compiler/xla/client/lib:svd",
     "@org_tensorflow//tensorflow/compiler/xla/client/lib:self_adjoint_eig",
+    "@org_tensorflow//tensorflow/compiler/xla/client/lib:sorting",
     "@org_tensorflow//tensorflow/compiler/xla:literal",
     "@org_tensorflow//tensorflow/compiler/xla:shape_util",
     "@org_tensorflow//tensorflow/compiler/xla:status",


### PR DESCRIPTION
Required to add `top_k` to EXLA which is required to add beam search to Bumblebee generation strategies