### PR TITLE
Use simplified locale on build

### DIFF
--- a/.github/builds/Dockerfile.cuda
+++ b/.github/builds/Dockerfile.cuda
@@ -4,10 +4,8 @@ FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-devel-ubuntu20.04
 
 ARG XLA_TARGET
 
-# Set the missing utf-8 locales, otherwise Elixir warns
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+# Set the missing UTF-8 locale, otherwise Elixir warns
+ENV LC_ALL C.UTF-8
 
 # Make sure installing packages (like tzdata) doesn't prompt for configuration
 ENV DEBIAN_FRONTEND noninteractive
@@ -19,11 +17,7 @@ RUN apt-get update && apt-get install -y software-properties-common && \
     # Add repository with the latest git version
     add-apt-repository ppa:git-core/ppa && \
     # Install basic system dependencies
-    apt-get update && apt-get install -y locales ca-certificates curl git unzip wget && \
-    # Update locales
-    echo "$LANG UTF-8" >> /etc/locale.gen && \
-    locale-gen && \
-    update-locale LANG=$LANG
+    apt-get update && apt-get install -y ca-certificates curl git unzip wget
 
 # Install Bazel
 RUN apt-get install -y apt-transport-https curl gnupg && \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,10 +179,8 @@ jobs:
       # This env is normally set by default, but we need to mirror it into the container
       # ourselves (used by the actions/setup-beam).
       ImageOS: ubuntu20
-      # Set the missing utf-8 locales, otherwise Elixir warns
-      LANG: en_US.UTF-8
-      LANGUAGE: en_US:en
-      LC_ALL: en_US.UTF-8
+      # Set the missing UTF-8 locale, otherwise Elixir warns
+      LC_ALL: C.UTF-8
       # Make sure installing packages (like tzdata) doesn't prompt for configuration
       DEBIAN_FRONTEND: noninteractive
     steps:
@@ -194,15 +192,11 @@ jobs:
           # Add repository with the latest git version for action/checkout to properly clone the repo
           add-apt-repository ppa:git-core/ppa
           # We run as root, so sudo is not necessary per se, but some actions (like setup-bazel) make use of it
-          apt-get update && apt-get install -y locales ca-certificates curl git sudo unzip wget
+          apt-get update && apt-get install -y ca-certificates curl git sudo unzip wget
           # Install GitHub CLI used by our scripts
           curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
           apt-get update && apt-get install -y gh
-          # Update locales
-          echo "$LANG UTF-8" >> /etc/locale.gen
-          locale-gen
-          update-locale LANG=$LANG
       # Prevent git from checking the repository owner and erroring with "dubious ownership"
       - run: git config --global --add safe.directory '*'
       # Proceed with the regular steps


### PR DESCRIPTION
It makes locale generation not required.
That also should be the only needed env variable in non-interactive context.