### PR TITLE
Bump the version requirements for CUDA 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ only the host CPU.
 | --- | --- |
 | cpu | |
 | tpu | libtpu |
-| cuda120 | CUDA 12.0+, cuDNN 8.8+ |
+| cuda120 | CUDA 12.1+, cuDNN 8.9+ |
 | cuda118 | CUDA 11.8+, cuDNN 8.6+ |
 | cuda | CUDA x.y, cuDNN (building from source only) |
 | rocm | ROCm (building from source only) |


### PR DESCRIPTION
Jax requires cuDNN 8.9, and at least based package list available on Ubuntu this also implies CUDA 12.1. I didn't find an explicit reason for 8.9, but it seems to address [possible issues](https://elixirforum.com/t/trying-the-bert-fine-tunning-on-gpu/58177) with the current precompiled archive, so I think it's worth bumping the requirement.