### PR TITLE
Add Docker build script for Linux ARM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,36 +180,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           XLA_TARGET: ${{ matrix.xla_target }}
-
-  linux_arm:
-    name: "aarch64-linux-gnu-cpu (cross-compiled)"
-    needs: [create_draft_release]
-    # We intentionally build on ubuntu 20 to compile against
-    # an older version of glibc
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: "24"
-          elixir-version: "1.12.3"
-      # Setup the compilation environment
-      - uses: abhinavsingh/setup-bazel@v3
-        with:
-          version: "6.1.2"
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.9"
-      - run: python -m pip install --upgrade pip numpy
-      # Build and upload the archives
-      - run: mix deps.get
-      # Hide system OpenSSL as suggested in https://github.com/tensorflow/tensorflow/issues/48401#issuecomment-818377995
-      - run: sudo mv /usr/include/openssl /usr/include/openssl.original
-      - run: .github/scripts/compile_and_upload.sh ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          XLA_TARGET: cpu
-          XLA_TARGET_PLATFORM: "aarch64-linux-gnu"
-          # Explicitly cross-compile for arm64
-          BUILD_FLAGS: "--config=elinux_aarch64"
-          CC: gcc-9

--- a/builds/build.sh
+++ b/builds/build.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 print_usage_and_exit() {
   echo "Usage: $0 <variant>"
   echo ""
-  echo "Compiles the project inside docker. Available variants: cuda118, cuda120."
+  echo "Compiles the project inside docker. Available variants: cpu, cuda118, cuda120."
   exit 1
 }
 
@@ -21,6 +21,14 @@ fi
 # [1]: https://docs.nvidia.com/deeplearning/cudnn/archives/index.html
 
 case "$1" in
+  "cpu")
+    docker build -t xla-cpu -f builds/cpu.Dockerfile \
+      --build-arg XLA_TARGET=cpu \
+      .
+
+    docker run --rm -v $(pwd)/builds/output/cpu/build:/build -v $(pwd)/builds/output/cpu/.cache:/root/.cache xla-cpu
+  ;;
+
   "cuda118")
     docker build -t xla-cuda118 -f builds/cuda.Dockerfile \
       --build-arg CUDA_VERSION=11.8.0 \

--- a/builds/cpu.Dockerfile
+++ b/builds/cpu.Dockerfile
@@ -1,10 +1,4 @@
-ARG CUDA_VERSION
-
 FROM hexpm/elixir:1.15.4-erlang-26.0.2-ubuntu-focal-20230126 AS elixir
-
-FROM nvidia/cuda:${CUDA_VERSION}-cudnn8-devel-ubuntu20.04
-
-ARG CUDNN_VERSION
 
 # Set the missing UTF-8 locale, otherwise Elixir warns
 ENV LC_ALL C.UTF-8
@@ -19,34 +13,17 @@ RUN apt-get update && apt-get install -y software-properties-common && \
   # Install basic system dependencies
   apt-get update && apt-get install -y ca-certificates curl git unzip wget
 
-# Install a specific cuDNN version over the default one
-RUN cuda_version="${CUDA_VERSION}" && \
-  cudnn_version="${CUDNN_VERSION}" && \
-  cudnn_package_version="$(apt-cache madison libcudnn8 | grep -o "${cudnn_version}.*-1+cuda${cuda_version%.*}")" && \
-  apt-get install -y --allow-downgrades --allow-change-held-packages libcudnn8=$cudnn_package_version libcudnn8-dev=$cudnn_package_version
-
 # Install Bazel using Bazelisk (works for both amd and arm)
 RUN wget -O bazel "https://github.com/bazelbuild/bazelisk/releases/download/v1.18.0/bazelisk-linux-$(dpkg --print-architecture)" && \
   chmod +x bazel && \
   mv bazel /usr/local/bin/bazel
 
-ENV USE_BAZEL_VERSION 6.1.2
+ENV USE_BAZEL_VERSION 6.1.0
 
 # Install Python and the necessary global dependencies
 RUN apt-get install -y python3 python3-pip && \
   ln -s /usr/bin/python3 /usr/bin/python && \
   python -m pip install --upgrade pip numpy
-
-# Install Erlang and Elixir
-
-# Erlang runtime dependencies, see https://github.com/hexpm/bob/blob/3b5721dccdfe9d59766f374e7b4fb7fb8a7c720e/priv/scripts/docker/erlang-ubuntu-focal.dockerfile#L41-L45
-RUN apt-get install -y --no-install-recommends libodbc1 libssl1.1 libsctp1
-
-# We copy the top-level directory first to preserve symlinks in /usr/local/bin
-COPY --from=elixir /usr/local /usr/ELIXIR_LOCAL
-RUN cp -r /usr/ELIXIR_LOCAL/lib/* /usr/local/lib && \
-  cp -r /usr/ELIXIR_LOCAL/bin/* /usr/local/bin && \
-  rm -rf /usr/ELIXIR_LOCAL
 
 # ---
 


### PR DESCRIPTION
Closes #59.

The CI cross-compilation for ARM no longer works as expected, so I added Docker scripts instead. I built it in the cloud both for CPU and CUDA and added all of them to the latest release.