### PR TITLE
Update TensorFlow repo URL to debug_options_flags.cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ You can use the following env vars to customize your build:
 ## Runtime flags
 
 You can further configure XLA runtime options with `XLA_FLAGS`,
-see: [tensorflow/compiler/xla/debug_options_flags.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/debug_options_flags.cc)
+see: [third_party/xla/xla/debug_options_flags.cc](https://github.com/tensorflow/tensorflow/blob/master/third_party/xla/xla/debug_options_flags.cc)
 for the list of available flags.
 
 ## Release process

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ You can use the following env vars to customize your build:
 ## Runtime flags
 
 You can further configure XLA runtime options with `XLA_FLAGS`,
-see: [third_party/xla/xla/debug_options_flags.cc](https://github.com/tensorflow/tensorflow/blob/master/third_party/xla/xla/debug_options_flags.cc)
+see: [xla/debug_options_flags.cc](https://github.com/openxla/xla/blob/main/xla/debug_options_flags.cc)
 for the list of available flags.
 
 ## Release process


### PR DESCRIPTION
Appears to have been renamed within the TF project since this was rewritten. Please double-check that the [new target](https://github.com/tensorflow/tensorflow/blob/master/third_party/xla/xla/debug_options_flags.cc) is the the content that was intended to link to.