### PR TITLE
Update supported CUDA targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,13 +115,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu20.04
-            xla_target: cuda118
-            cuda_version: "11.8.0"
-            cudnn_version: "8.6.0"
-            python: "3.9"
           - container: nvidia/cuda:12.0.0-cudnn8-devel-ubuntu20.04
-            xla_target: cuda120
+            xla_target: cuda12
             cuda_version: "12.0.0"
             cudnn_version: "8.8.0"
             python: "3.9"

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ only the host CPU.
 | --- | --- |
 | cpu | |
 | tpu | libtpu |
-| cuda120 | CUDA 12.1+, cuDNN 8.9+ |
-| cuda118 | CUDA 11.8+, cuDNN 8.6+ |
+| cuda12 | CUDA 12.1+, cuDNN 8.9+ |
 | cuda | CUDA x.y, cuDNN (building from source only) |
 | rocm | ROCm (building from source only) |
 
@@ -34,7 +33,7 @@ and [cuDNN](https://developer.nvidia.com/cudnn) compatible with your GPU drivers
 See [the installation instructions](https://docs.nvidia.com/deeplearning/cudnn/install-guide/index.html)
 and [the cuDNN support matrix](https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html)
 for version compatibility. To use precompiled XLA binaries specify a target matching
-your CUDA version (like `cuda118`). You can find your CUDA version by running `nvcc --version`
+your CUDA version (like `cuda12`). You can find your CUDA version by running `nvcc --version`
 (note that `nvidia-smi` shows the highest supported CUDA version, not the installed one).
 When building from source it's enough to specify `cuda` as the target.
 

--- a/builds/README.md
+++ b/builds/README.md
@@ -7,14 +7,14 @@ This directory contains Docker-based automated builds to run off-CI.
 Run the build script, passing one of the defined variants.
 
 ```shell
-./build.sh cuda118
+./build.sh cuda12
 ```
 
 When running on a remote server, it's important to detach the process,
 so that it keeps running if the ssh connection is closed:
 
 ```shell
-nohup time builds/build.sh cuda118 > build.log 2>&1 &
+nohup time builds/build.sh cuda12 > build.log 2>&1 &
 tail -f build.log
 ```
 

--- a/builds/build.sh
+++ b/builds/build.sh
@@ -7,7 +7,7 @@ cd "$(dirname "$0")/.."
 print_usage_and_exit() {
   echo "Usage: $0 <variant>"
   echo ""
-  echo "Compiles the project inside docker. Available variants: cpu, cuda118, cuda120, tpu, rocm."
+  echo "Compiles the project inside docker. Available variants: cpu, cuda12, tpu, rocm."
   exit 1
 }
 
@@ -45,32 +45,18 @@ case "$1" in
       xla-tpu
   ;;
 
-  "cuda118")
-    docker build -t xla-cuda118 -f builds/cuda.Dockerfile \
-      --build-arg CUDA_VERSION=11.8.0 \
-      --build-arg CUDNN_VERSION=8.6.0 \
-      --build-arg XLA_TARGET=cuda118 \
-      .
-
-    docker run --rm \
-      -v $(pwd)/builds/output/cuda118/build:/build \
-      -v $(pwd)/builds/output/cuda118/.cache:/root/.cache \
-      $XLA_DOCKER_FLAGS \
-      xla-cuda118
-  ;;
-
-  "cuda120")
-    docker build -t xla-cuda120 -f builds/cuda.Dockerfile \
+  "cuda12")
+    docker build -t xla-cuda12 -f builds/cuda.Dockerfile \
       --build-arg CUDA_VERSION=12.1.0 \
       --build-arg CUDNN_VERSION=8.9.0 \
-      --build-arg XLA_TARGET=cuda120 \
+      --build-arg XLA_TARGET=cuda12 \
       .
 
     docker run --rm \
-      -v $(pwd)/builds/output/cuda120/build:/build \
-      -v $(pwd)/builds/output/cuda120/.cache:/root/.cache \
+      -v $(pwd)/builds/output/cuda12/build:/build \
+      -v $(pwd)/builds/output/cuda12/.cache:/root/.cache \
       $XLA_DOCKER_FLAGS \
-      xla-cuda120
+      xla-cuda12
   ;;
 
   "rocm")

--- a/lib/xla.ex
+++ b/lib/xla.ex
@@ -46,7 +46,7 @@ defmodule XLA do
   defp xla_target() do
     target = System.get_env("XLA_TARGET", "cpu")
 
-    supported_xla_targets = ["cpu", "cuda", "rocm", "tpu", "cuda118", "cuda120"]
+    supported_xla_targets = ["cpu", "cuda", "rocm", "tpu", "cuda12"]
 
     unless target in supported_xla_targets do
       listing = supported_xla_targets |> Enum.map(&inspect/1) |> Enum.join(", ")


### PR DESCRIPTION
While creating a new build for 11.8, I run into errors (same as https://github.com/tensorflow/tensorflow/issues/63356). Given that both latest Tensorflow and Jax require CUDA 12, it's fair for us to require it as well.

I also took this as an opportunity to rename "cuda120" to "cuda12" (closes #55).