### PR TITLE
add < 9 for cuDNN spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ only the host CPU.
 | --- | --- |
 | cpu | |
 | tpu | libtpu |
-| cuda12 | CUDA 12.1+, cuDNN 8.9+ |
+| cuda12 | CUDA 12.1+, cuDNN 8.9+, < 9 |
 | cuda | CUDA x.y, cuDNN (building from source only) |
 | rocm | ROCm (building from source only) |
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ only the host CPU.
 | --- | --- |
 | cpu | |
 | tpu | libtpu |
-| cuda12 | CUDA 12.1+, cuDNN 8.9+, < 9 |
+| cuda12 | CUDA 12.1+, cuDNN 8.9+ and < 9 |
 | cuda | CUDA x.y, cuDNN (building from source only) |
 | rocm | ROCm (building from source only) |
 


### PR DESCRIPTION
We should specify that cuDNN needs to be < 9, 8.9+ may lead people to think that version 9 also works.

From what I saw here are relevant issues #86 #79 that I believe this PR will prevent.