### PR TITLE
Default target to CUDA when installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ need to export it in every shell session.
 
 #### `XLA_TARGET`
 
-The default value is `cpu`, which implies the final the binary supports targeting
-only the host CPU.
+The default value is usually `cpu`, which implies the final the binary supports targeting
+only the host CPU. If a matching CUDA version is detected, the target is set to CUDA accordingly.
 
 | Value | Target environment |
 | --- | --- |

--- a/lib/xla.ex
+++ b/lib/xla.ex
@@ -44,7 +44,7 @@ defmodule XLA do
   end
 
   defp xla_target() do
-    target = System.get_env("XLA_TARGET", "cpu")
+    target = System.get_env("XLA_TARGET") || infer_xla_target() || "cpu"
 
     supported_xla_targets = ["cpu", "cuda", "rocm", "tpu", "cuda12"]
 
@@ -54,6 +54,13 @@ defmodule XLA do
     end
 
     target
+  end
+
+  defp infer_xla_target() do
+    if nvcc = System.find_executable("nvcc") do
+      {output, 0} = System.cmd(nvcc, ["--version"])
+      if output =~ "release 12.", do: "cuda12"
+    end
   end
 
   defp xla_cache_dir() do

--- a/lib/xla.ex
+++ b/lib/xla.ex
@@ -57,9 +57,11 @@ defmodule XLA do
   end
 
   defp infer_xla_target() do
-    if nvcc = System.find_executable("nvcc") do
-      {output, 0} = System.cmd(nvcc, ["--version"])
+    with nvcc when nvcc != nil <- System.find_executable("nvcc"),
+         {output, 0} <- System.cmd(nvcc, ["--version"]) do
       if output =~ "release 12.", do: "cuda12"
+    else
+      _ -> nil
     end
   end
 


### PR DESCRIPTION
This way users don't need to remember about setting `XLA_TARGET`, which provides a better out of the box experience.