### PR TITLE
Improve precompiled downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ xla-*.tar
 
 # Output from compilations within Docker
 /builds/output/
+
+# Archive checksums file
+/checksum.txt

--- a/README.md
+++ b/README.md
@@ -76,12 +76,6 @@ The target triplet describing the target platform, such as `aarch64-linux-gcc`. 
 this target is inferred for the host, however you may want to override this when cross-compiling
 the project using Nerves.
 
-#### `XLA_HTTP_HEADERS`
-
-Headers to use when querying and downloading the precompiled archive. By default the
-requests are sent to GitHub, unless `XLA_ARCHIVE_URL` specifies otherwise. The headers
-should be a list following this format: `Key1: Value1; Key2: value2`.
-
 ## Building from source
 
 > Note: currently only macOS and Linux is supported. When on Windows, the best option

--- a/lib/mix/tasks/xla.checksum.ex
+++ b/lib/mix/tasks/xla.checksum.ex
@@ -1,0 +1,41 @@
+defmodule Mix.Tasks.Xla.Checksum do
+  @moduledoc """
+  Generates a checksum file for all precompiled artifacts.
+  """
+
+  use Mix.Task
+
+  @impl true
+  def run(_args) do
+    XLA.Utils.start_inets_profile()
+
+    Mix.shell().info("Downloading and computing checksums...")
+
+    checksums =
+      XLA.precompiled_files()
+      |> Task.async_stream(
+        fn {filename, url} ->
+          {filename, download_checksum!(url)}
+        end,
+        timeout: :infinity,
+        ordered: false
+      )
+      |> Map.new(fn {:ok, {filename, checksum}} -> {filename, checksum} end)
+
+    XLA.write_checksums!(checksums)
+
+    Mix.shell().info("Checksums written")
+  after
+    XLA.Utils.stop_inets_profile()
+  end
+
+  defp download_checksum!(url) do
+    case XLA.Utils.download(url, %XLA.Checksumer{}) do
+      {:ok, checksum} ->
+        checksum
+
+      {:error, message} ->
+        Mix.raise("failed to download archive from #{url}, reason: #{message}")
+    end
+  end
+end

--- a/lib/mix/tasks/xla.info.ex
+++ b/lib/mix/tasks/xla.info.ex
@@ -11,7 +11,7 @@ defmodule Mix.Tasks.Xla.Info do
   end
 
   def run(["release_tag"]) do
-    Mix.shell().info(XLA.release_tag())
+    Mix.shell().info("v" <> XLA.version())
   end
 
   def run(["build_archive_dir"]) do

--- a/lib/xla/checksumer.ex
+++ b/lib/xla/checksumer.ex
@@ -1,0 +1,25 @@
+defmodule XLA.Checksumer do
+  @moduledoc false
+
+  defstruct algorithm: :sha256
+
+  defimpl Collectable do
+    def into(checksumer) do
+      state = :crypto.hash_init(checksumer.algorithm)
+
+      collector = fn
+        state, {:cont, chunk} when is_binary(chunk) ->
+          :crypto.hash_update(state, chunk)
+
+        state, :done ->
+          hash = :crypto.hash_final(state)
+          Base.encode16(hash, case: :lower)
+
+        _state, :halt ->
+          :ok
+      end
+
+      {state, collector}
+    end
+  end
+end

--- a/lib/xla/utils.ex
+++ b/lib/xla/utils.ex
@@ -1,0 +1,160 @@
+defmodule XLA.Utils do
+  @moduledoc false
+
+  @doc """
+  Downloads resource at the given URL into `collectable`.
+
+  If collectable raises an error, it is rescued and an error tuple
+  is returned.
+
+  ## Options
+
+    * `:headers` - request headers
+
+  """
+  @spec download(String.t(), Collectable.t(), keyword()) ::
+          {:ok, Collectable.t()} | {:error, String.t()}
+  def download(url, collectable, opts \\ []) do
+    headers = build_headers(opts[:headers] || [])
+
+    request = {url, headers}
+    http_opts = [ssl: http_ssl_opts()]
+
+    caller = self()
+
+    receiver = fn reply_info ->
+      request_id = elem(reply_info, 0)
+
+      # Cancel the request if the caller terminates
+      if Process.alive?(caller) do
+        send(caller, {:http, reply_info})
+      else
+        :httpc.cancel_request(request_id, :xla)
+      end
+    end
+
+    opts = [stream: :self, sync: false, receiver: receiver]
+
+    {:ok, request_id} = :httpc.request(:get, request, http_opts, opts, :xla)
+
+    try do
+      {acc, collector} = Collectable.into(collectable)
+
+      try do
+        download_loop(%{request_id: request_id, acc: acc, collector: collector})
+      catch
+        kind, reason ->
+          collector.(acc, :halt)
+          :httpc.cancel_request(request_id, :xla)
+          exception = Exception.normalize(kind, reason, __STACKTRACE__)
+          {:error, Exception.message(exception)}
+      else
+        {:ok, state} ->
+          acc = state.collector.(state.acc, :done)
+          {:ok, acc}
+
+        {:error, message} ->
+          collector.(acc, :halt)
+          :httpc.cancel_request(request_id, :xla)
+          {:error, message}
+      end
+    catch
+      kind, reason ->
+        :httpc.cancel_request(request_id, :xla)
+        exception = Exception.normalize(kind, reason, __STACKTRACE__)
+        {:error, Exception.message(exception)}
+    end
+  end
+
+  defp build_headers(entries) do
+    headers =
+      Enum.map(entries, fn {key, value} ->
+        {to_charlist(key), to_charlist(value)}
+      end)
+
+    [{~c"user-agent", ~c"elixir-nx/xla"} | headers]
+  end
+
+  defp download_loop(state) do
+    receive do
+      {:http, reply_info} when elem(reply_info, 0) == state.request_id ->
+        download_receive(state, reply_info)
+    end
+  end
+
+  defp download_receive(_state, {_, {:error, error}}) do
+    {:error, "reason: #{inspect(error)}"}
+  end
+
+  defp download_receive(state, {_, {{_, 200, _}, _headers, body}}) do
+    acc = state.collector.(state.acc, {:cont, body})
+    {:ok, %{state | acc: acc}}
+  end
+
+  defp download_receive(_state, {_, {{_, status, _}, _headers, _body}}) do
+    {:error, "got HTTP status #{status}"}
+  end
+
+  defp download_receive(state, {_, :stream_start, _headers}) do
+    download_loop(state)
+  end
+
+  defp download_receive(state, {_, :stream, body_part}) do
+    acc = state.collector.(state.acc, {:cont, body_part})
+    download_loop(%{state | acc: acc})
+  end
+
+  defp download_receive(state, {_, :stream_end, _headers}) do
+    {:ok, state}
+  end
+
+  defp http_ssl_opts() do
+    # Use secure options, see https://gist.github.com/jonatanklosko/5e20ca84127f6b31bbe3906498e1a1d7
+    [
+      cacerts: :public_key.cacerts_get(),
+      verify: :verify_peer,
+      customize_hostname_check: [
+        match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+      ]
+    ]
+  end
+
+  @doc false
+  def start_inets_profile() do
+    # Starting an HTTP client profile allows us to scope the httpc
+    # configuration options, such as proxy options
+    {:ok, _pid} = :inets.start(:httpc, profile: :xla)
+    set_proxy_options()
+  end
+
+  @doc false
+  def stop_inets_profile() do
+    :inets.stop(:httpc, :xla)
+  end
+
+  defp set_proxy_options() do
+    http_proxy = System.get_env("HTTP_PROXY") || System.get_env("http_proxy")
+    https_proxy = System.get_env("HTTPS_PROXY") || System.get_env("https_proxy")
+
+    no_proxy =
+      if no_proxy = System.get_env("NO_PROXY") || System.get_env("no_proxy") do
+        no_proxy
+        |> String.split(",")
+        |> Enum.map(&String.to_charlist/1)
+      else
+        []
+      end
+
+    set_proxy_option(:proxy, http_proxy, no_proxy)
+    set_proxy_option(:https_proxy, https_proxy, no_proxy)
+  end
+
+  defp set_proxy_option(proxy_scheme, proxy, no_proxy) do
+    uri = URI.parse(proxy || "")
+
+    if uri.host && uri.port do
+      host = String.to_charlist(uri.host)
+      :httpc.set_options([{proxy_scheme, {{host, uri.port}, no_proxy}}], :xla)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule XLA.MixProject do
       version: @version,
       description: "Precompiled XLA binaries",
       elixir: "~> 1.12",
+      aliases: aliases(),
       deps: deps(),
       compilers: Mix.compilers() ++ if(build?(), do: [:elixir_make], else: []),
       make_env: &XLA.make_env/0,
@@ -18,7 +19,15 @@ defmodule XLA.MixProject do
   end
 
   def application do
-    [extra_applications: [:logger]]
+    [extra_applications: [:logger, :inets, :ssl, :public_key, :crypto]]
+  end
+
+  def aliases do
+    [
+      # When compiling the checksum task, code paths are pruned, so we
+      # explicitly load hex back
+      "hex.publish": ["xla.checksum", fn _ -> Mix.ensure_application!(:hex) end, "hex.publish"]
+    ]
   end
 
   defp deps do
@@ -34,7 +43,7 @@ defmodule XLA.MixProject do
       links: %{
         "GitHub" => "https://github.com/elixir-nx/xla"
       },
-      files: ~w(extension lib Makefile mix.exs README.md LICENSE CHANGELOG.md)
+      files: ~w(extension lib Makefile mix.exs README.md LICENSE CHANGELOG.md checksum.txt)
     ]
   end
 


### PR DESCRIPTION
The following changes:

1. Adds integrity checking with checksums. When running `hex.publish`, we now automatically generate a `checksum.txt` file and include it in the hex package. Then, when we download the archive, we compare the checksum.

2. We use `:httpc` instead of relying on `wget`/`curl` being installed. IIRC we did that initially to have an efficient stream download, instead of downloading the whole binary into memory, but the `:httpc` implementation stream downloads also.

3. We no longer query the GitHub API to list the release artifacts. Instead, we hard-code the list of precompiled targets in the module, so we know what's available upfront.

4. I removed `XLA_HTTP_HEADERS` env var. The original purpose was to allow GitHub auth token, to avoid GitHub API rate limiting on CI (https://github.com/elixir-nx/xla/issues/52#issuecomment-1686162988). With 3. this should be no longer necessary, since we don't query that API.

Closes #92.