### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ only the host CPU. If a matching CUDA version is detected, the target is set to 
 | --- | --- |
 | cpu | |
 | tpu | libtpu |
-| cuda12 | CUDA >= 12.1, cuDNN >= 9.1 and < 10.0 |
+| cuda120 | CUDA >= 12.1, cuDNN >= 9.1 and < 10.0 |
+| cuda118 | CUDA >= 11.8 and <= 12, cuDNN |
 | cuda | CUDA x.y, cuDNN (building from source only) |
 | rocm | ROCm (building from source only) |
 


### PR DESCRIPTION
Fixes the following error

```sh
❯ XLA_TARGET=cuda12  mix compile
==> exla
could not compile dependency :exla, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile exla --force", update it with "mix deps.update exla" or clean it with "mix deps.clean exla"
** (RuntimeError) expected XLA_TARGET to be one of "cpu", "cuda", "rocm", "tpu", "cuda118", "cuda120", but got: "cuda12"
    (xla 0.6.0) lib/xla.ex:53: XLA.xla_target/0
    (xla 0.6.0) lib/xla.ex:128: XLA.target/0
    (xla 0.6.0) lib/xla.ex:122: XLA.archive_filename_with_target/0
    (xla 0.6.0) lib/xla.ex:169: XLA.archive_path_for_matching_download/0
    (xla 0.6.0) lib/xla.ex:32: XLA.archive_path!/0
    /home/feynman/code/excision/deps/exla/mix.exs:113: EXLA.MixProject.extract_xla/1
    (mix 1.17.2) lib/mix/task.ex:574: Mix.Task.run_alias/6
    (mix 1.17.2) lib/mix/tasks/compile.all.ex:108: Mix.Tasks.Compile.All.run_compiler/2


```