### PR TITLE
Support XLA_ARCHIVE_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ Building has a number of dependencies, see *Building from source* below.
 A URL pointing to a specific build of the `.tar.gz` archive. When using this option
 you need to make sure the build matches your OS, CPU architecture and the XLA target.
 
+#### `XLA_ARCHIVE_PATH`
+
+Just like `XLA_ARCHIVE_URL`, but pointing to a local `.tar.gz` archive file.
+
 #### `XLA_CACHE_DIR`
 
 The directory to store the downloaded and built archives in. Defaults to the standard

--- a/lib/xla.ex
+++ b/lib/xla.ex
@@ -38,6 +38,9 @@ defmodule XLA do
         # The archive should have already been built by this point
         archive_path_for_build()
 
+      path = xla_archive_path() ->
+        path
+
       url = xla_archive_url() ->
         path = archive_path_for_external_download(url)
         unless File.exists?(path), do: download_external!(url, path)
@@ -54,6 +57,10 @@ defmodule XLA do
 
   defp build?() do
     System.get_env("XLA_BUILD") in ~w(1 true)
+  end
+
+  defp xla_archive_path() do
+    System.get_env("XLA_ARCHIVE_PATH")
   end
 
   defp xla_archive_url() do


### PR DESCRIPTION
> Just like `XLA_ARCHIVE_URL`, but pointing to a local `.tar.gz` archive file.