### PR TITLE
Use XDG_CACHE_HOME if set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 # BUILD_INTERNAL_FLAGS
 
 # System vars
-TEMP ?= $(HOME)/.cache
+XDG_CACHE_HOME ?= $(HOME)/.cache # Default ENV for cache on Linux
+TEMP ?= $(XDG_CACHE_HOME)
 
 # Public configuration
 BUILD_MODE ?= opt # can also be dbg


### PR DESCRIPTION
Use the XDG_CACHE_HOME if set to work like Bazel
and other tools on Linux