### PR TITLE
Add sm_120 native cubin for Blackwell consumer GPUs

### DIFF
--- a/lib/xla.ex
+++ b/lib/xla.ex
@@ -336,7 +336,7 @@ defmodule XLA do
                   ~s/--repo_env=HERMETIC_CUDNN_VERSION="9.8.0"/,
                   ~s/--repo_env=HERMETIC_NVSHMEM_VERSION="3.3.9"/,
                   ~s/--repo_env=HERMETIC_NCCL_VERSION="2.27.7"/,
-                  ~s/--repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_50,sm_60,sm_70,sm_80,sm_90,sm_100,compute_120"/
+                  ~s/--repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_50,sm_60,sm_70,sm_80,sm_90,sm_100,sm_120,compute_120"/
                 ]
 
               "cuda13" ->
@@ -346,7 +346,7 @@ defmodule XLA do
                   ~s/--repo_env=HERMETIC_CUDNN_VERSION="9.12.0"/,
                   ~s/--repo_env=HERMETIC_NVSHMEM_VERSION="3.3.20"/,
                   ~s/--repo_env=HERMETIC_NCCL_VERSION="2.27.7"/,
-                  ~s/--repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_75,sm_80,sm_90,sm_100,compute_120"/
+                  ~s/--repo_env HERMETIC_CUDA_COMPUTE_CAPABILITIES="sm_75,sm_80,sm_90,sm_100,sm_120,compute_120"/
                 ]
 
               "cuda" ->


### PR DESCRIPTION
The cuda12 and cuda13 build targets include sm_100 (datacenter Blackwell) as a native cubin but only compute_120 (consumer Blackwell) as PTX. This means consumer Blackwell GPUs (RTX 5090, etc.) rely on JIT compilation of PTX at runtime rather than using a precompiled native cubin.

Adding sm_120 provides native cubin for consumer Blackwell GPUs, avoiding JIT compilation overhead on first run and ensuring the autotuner has architecture-specific kernels available.

(which is good for me personally)